### PR TITLE
Corrected the path for background-image

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,7 +17,8 @@
 }
 
 body {
-  background-image: url("/images/bg-desktop.svg");
+  /* background-image: url("/images/bg-desktop.svg"); */
+  background-image: url("../images/bg-desktop.svg");  /* This is the correct file-path */
   background-repeat: no-repeat;
   background-size: cover;
   min-height: 100vh;


### PR DESCRIPTION
You had provided the wrong file-path for background image

`background-image: url("/images/bg-desktop.svg");`

Since the image was not in the same directory as the **_style.css_** file we have to go back a directory to fetch the image. This is done using `../` .

Hence the correct file-path should be:
`background-image: url("../images/bg-desktop.svg");`

Before:
![keerthivalla github io_Huddle-Introductory_](https://user-images.githubusercontent.com/74287708/116643480-cf1a7580-a98e-11eb-87be-38c78065c5de.png)

After:
![Screenshot 2021-04-30 083537](https://user-images.githubusercontent.com/74287708/116643515-dd689180-a98e-11eb-8ed1-14ced4f45d1f.png)
